### PR TITLE
replaced deprecated setColor function, fixed main argc check, replace…

### DIFF
--- a/makefile
+++ b/makefile
@@ -8,7 +8,7 @@ EXE := gameboy.out
 CXX := clang++
 RM := -rm -rf
 # Compiler and dynamic link flags:
-CXXFLAGS  := -std=c++14 -Wall -mcpu=native
+CXXFLAGS  := -std=c++14 -Wall -march=native
 # CXXFLAGS  := -std=c++14 -Wall --march=native --mtune=native
 LDFLAGS   := -lsfml-graphics -lsfml-window -lsfml-system
 # Directories

--- a/src/context/context.cpp
+++ b/src/context/context.cpp
@@ -26,7 +26,7 @@ bool prevShouldStep = false;
 bool Context::SetupContext (int scale = 1) {
 	font.loadFromFile("./resources/fonts/OpenSans-Bold.ttf");
 	debugText.setFont(font);
-	debugText.setColor(sf::Color::Magenta);
+	debugText.setFillColor(sf::Color::Magenta);
 	debugText.setCharacterSize(20);
 	debugText.setString("Debug :D");
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,6 +17,7 @@ int main(int argc, char const *argv[]) {
 	if (argc < 2) {
 		std::cout << "<*Error*> You didn't supply a ROM path as argument\n" <<
 		             "Usage example: ./build/gbemu.out roms/tetris.gb\n";
+		return EXIT_FAILURE;
 	}
 
 	const char* filepath = argv[1];
@@ -24,7 +25,7 @@ int main(int argc, char const *argv[]) {
 	Rom rom(filepath);
 	if (rom.isLoaded == false) {
 		std::cout << "<*Error*> Failed to load: " << filepath << " \n";
-		return 1;
+		return EXIT_FAILURE;
 	}
 
 	if (rom.isLoaded) {
@@ -75,5 +76,5 @@ int main(int argc, char const *argv[]) {
 
 	Context::DestroyContext();
 
-	return 0;
+	return EXIT_SUCCESS;
 }


### PR DESCRIPTION
…d unused argument -mcpu=native for -march=native.

Hi, I just compiled and had a look at your code here, and I fixed some minor issues.
My installed clang compiler 3.9.1, complains about the -mcpu=native flag, so I replaced it with -march=native, which I believe is doing the intended thing.

I couldn't compile for SFML is complaining about that setColor method in Text class is deprecated, and should be replaced by setFillColor and / or setOutlineColor.

And I added a return in your argc check in main. Also replaced the main return codes with the approprieted standard macros. 